### PR TITLE
opentelemetry: remove per-update allocation & global lock

### DIFF
--- a/tracing-opentelemetry/src/metrics.rs
+++ b/tracing-opentelemetry/src/metrics.rs
@@ -1,8 +1,4 @@
-use std::{
-    collections::HashMap,
-    fmt,
-    sync::{Arc, RwLock},
-};
+use std::{collections::HashMap, fmt, sync::RwLock};
 use tracing::{field::Visit, Collect};
 use tracing_core::Field;
 
@@ -22,16 +18,18 @@ const I64_MAX: u64 = i64::MAX as u64;
 
 #[derive(Default)]
 pub(crate) struct Instruments {
-    pub(crate) u64_counter: HashMap<String, Counter<u64>>,
-    pub(crate) f64_counter: HashMap<String, Counter<f64>>,
-    pub(crate) i64_up_down_counter: HashMap<String, UpDownCounter<i64>>,
-    pub(crate) f64_up_down_counter: HashMap<String, UpDownCounter<f64>>,
-    pub(crate) u64_value_recorder: HashMap<String, ValueRecorder<u64>>,
-    pub(crate) i64_value_recorder: HashMap<String, ValueRecorder<i64>>,
-    pub(crate) f64_value_recorder: HashMap<String, ValueRecorder<f64>>,
+    u64_counter: MetricsMap<Counter<u64>>,
+    f64_counter: MetricsMap<Counter<f64>>,
+    i64_up_down_counter: MetricsMap<UpDownCounter<i64>>,
+    f64_up_down_counter: MetricsMap<UpDownCounter<f64>>,
+    u64_value_recorder: MetricsMap<ValueRecorder<u64>>,
+    i64_value_recorder: MetricsMap<ValueRecorder<i64>>,
+    f64_value_recorder: MetricsMap<ValueRecorder<f64>>,
 }
 
-#[derive(Debug)]
+type MetricsMap<T> = RwLock<HashMap<String, T>>;
+
+#[derive(Copy, Clone, Debug)]
 pub(crate) enum InstrumentType {
     CounterU64(u64),
     CounterF64(f64),
@@ -43,68 +41,96 @@ pub(crate) enum InstrumentType {
 }
 
 impl Instruments {
-    pub(crate) fn init_metric_for(
-        &mut self,
+    pub(crate) fn update_metric(
+        &self,
         meter: &Meter,
         instrument_type: InstrumentType,
-        metric_name: String,
+        metric_name: &str,
     ) {
+        fn update_or_insert<T>(
+            map: &MetricsMap<T>,
+            name: &str,
+            insert: impl FnOnce() -> T,
+            update: impl FnOnce(&T),
+        ) {
+            let lock = map.read().unwrap();
+            if let Some(metric) = lock.get(name) {
+                update(metric);
+                return;
+            }
+
+            // that metric did not already exist, so we have to acquire a write lock to
+            // create it.
+            let mut lock = map.write().unwrap();
+            // handle the case where the entry was created while we were waiting to
+            // acquire the write lock
+            let metric = lock.entry(name.to_owned()).or_insert_with(insert);
+            update(metric)
+        }
+
         match instrument_type {
             InstrumentType::CounterU64(value) => {
-                let ctr = self
-                    .u64_counter
-                    .entry(metric_name.clone())
-                    .or_insert_with(|| meter.u64_counter(metric_name).init());
-                ctr.add(value, &[]);
+                update_or_insert(
+                    &self.u64_counter,
+                    metric_name,
+                    || meter.u64_counter(metric_name).init(),
+                    |ctr| ctr.add(value, &[]),
+                );
             }
             InstrumentType::CounterF64(value) => {
-                let ctr = self
-                    .f64_counter
-                    .entry(metric_name.clone())
-                    .or_insert_with(|| meter.f64_counter(metric_name).init());
-                ctr.add(value, &[]);
+                update_or_insert(
+                    &self.f64_counter,
+                    metric_name,
+                    || meter.f64_counter(metric_name).init(),
+                    |ctr| ctr.add(value, &[]),
+                );
             }
             InstrumentType::UpDownCounterI64(value) => {
-                let ctr = self
-                    .i64_up_down_counter
-                    .entry(metric_name.clone())
-                    .or_insert_with(|| meter.i64_up_down_counter(metric_name).init());
-                ctr.add(value, &[]);
+                update_or_insert(
+                    &self.i64_up_down_counter,
+                    metric_name,
+                    || meter.i64_up_down_counter(metric_name).init(),
+                    |ctr| ctr.add(value, &[]),
+                );
             }
             InstrumentType::UpDownCounterF64(value) => {
-                let ctr = self
-                    .f64_up_down_counter
-                    .entry(metric_name.clone())
-                    .or_insert_with(|| meter.f64_up_down_counter(metric_name).init());
-                ctr.add(value, &[]);
+                update_or_insert(
+                    &self.f64_up_down_counter,
+                    metric_name,
+                    || meter.f64_up_down_counter(metric_name).init(),
+                    |ctr| ctr.add(value, &[]),
+                );
             }
             InstrumentType::ValueRecorderU64(value) => {
-                let rec = self
-                    .u64_value_recorder
-                    .entry(metric_name.clone())
-                    .or_insert_with(|| meter.u64_value_recorder(metric_name).init());
-                rec.record(value, &[]);
+                update_or_insert(
+                    &self.u64_value_recorder,
+                    metric_name,
+                    || meter.u64_value_recorder(metric_name).init(),
+                    |rec| rec.record(value, &[]),
+                );
             }
             InstrumentType::ValueRecorderI64(value) => {
-                let rec = self
-                    .i64_value_recorder
-                    .entry(metric_name.clone())
-                    .or_insert_with(|| meter.i64_value_recorder(metric_name).init());
-                rec.record(value, &[]);
+                update_or_insert(
+                    &self.i64_value_recorder,
+                    metric_name,
+                    || meter.i64_value_recorder(metric_name).init(),
+                    |rec| rec.record(value, &[]),
+                );
             }
             InstrumentType::ValueRecorderF64(value) => {
-                let rec = self
-                    .f64_value_recorder
-                    .entry(metric_name.clone())
-                    .or_insert_with(|| meter.f64_value_recorder(metric_name).init());
-                rec.record(value, &[]);
+                update_or_insert(
+                    &self.f64_value_recorder,
+                    metric_name,
+                    || meter.f64_value_recorder(metric_name).init(),
+                    |rec| rec.record(value, &[]),
+                );
             }
         };
     }
 }
 
 pub(crate) struct MetricVisitor<'a> {
-    pub(crate) instruments: &'a Arc<RwLock<Instruments>>,
+    pub(crate) instruments: &'a Instruments,
     pub(crate) meter: &'a Meter,
 }
 
@@ -115,17 +141,17 @@ impl<'a> Visit for MetricVisitor<'a> {
 
     fn record_u64(&mut self, field: &Field, value: u64) {
         if field.name().starts_with(METRIC_PREFIX_MONOTONIC_COUNTER) {
-            self.instruments.write().unwrap().init_metric_for(
+            self.instruments.update_metric(
                 self.meter,
                 InstrumentType::CounterU64(value),
-                field.name().to_string(),
+                field.name(),
             );
         } else if field.name().starts_with(METRIC_PREFIX_COUNTER) {
             if value <= I64_MAX {
-                self.instruments.write().unwrap().init_metric_for(
+                self.instruments.update_metric(
                     self.meter,
                     InstrumentType::UpDownCounterI64(value as i64),
-                    field.name().to_string(),
+                    field.name(),
                 );
             } else {
                 eprintln!(
@@ -136,54 +162,54 @@ impl<'a> Visit for MetricVisitor<'a> {
                 );
             }
         } else if field.name().starts_with(METRIC_PREFIX_VALUE) {
-            self.instruments.write().unwrap().init_metric_for(
+            self.instruments.update_metric(
                 self.meter,
                 InstrumentType::ValueRecorderU64(value),
-                field.name().to_string(),
+                field.name(),
             );
         }
     }
 
     fn record_f64(&mut self, field: &Field, value: f64) {
         if field.name().starts_with(METRIC_PREFIX_MONOTONIC_COUNTER) {
-            self.instruments.write().unwrap().init_metric_for(
+            self.instruments.update_metric(
                 self.meter,
                 InstrumentType::CounterF64(value),
-                field.name().to_string(),
+                field.name(),
             );
         } else if field.name().starts_with(METRIC_PREFIX_COUNTER) {
-            self.instruments.write().unwrap().init_metric_for(
+            self.instruments.update_metric(
                 self.meter,
                 InstrumentType::UpDownCounterF64(value),
-                field.name().to_string(),
+                field.name(),
             );
         } else if field.name().starts_with(METRIC_PREFIX_VALUE) {
-            self.instruments.write().unwrap().init_metric_for(
+            self.instruments.update_metric(
                 self.meter,
                 InstrumentType::ValueRecorderF64(value),
-                field.name().to_string(),
+                field.name(),
             );
         }
     }
 
     fn record_i64(&mut self, field: &Field, value: i64) {
         if field.name().starts_with(METRIC_PREFIX_MONOTONIC_COUNTER) {
-            self.instruments.write().unwrap().init_metric_for(
+            self.instruments.update_metric(
                 self.meter,
                 InstrumentType::CounterU64(value as u64),
-                field.name().to_string(),
+                field.name(),
             );
         } else if field.name().starts_with(METRIC_PREFIX_COUNTER) {
-            self.instruments.write().unwrap().init_metric_for(
+            self.instruments.update_metric(
                 self.meter,
                 InstrumentType::UpDownCounterI64(value),
-                field.name().to_string(),
+                field.name(),
             );
         } else if field.name().starts_with(METRIC_PREFIX_VALUE) {
-            self.instruments.write().unwrap().init_metric_for(
+            self.instruments.update_metric(
                 self.meter,
                 InstrumentType::ValueRecorderI64(value),
-                field.name().to_string(),
+                field.name(),
             );
         }
     }
@@ -302,18 +328,19 @@ impl<'a> Visit for MetricVisitor<'a> {
 /// its callsite. However, per-callsite storage is not yet supported by tracing.
 pub struct OpenTelemetryMetricsSubscriber {
     meter: Meter,
-    instruments: Arc<RwLock<Instruments>>,
+    instruments: Instruments,
 }
 
 impl OpenTelemetryMetricsSubscriber {
     /// Create a new instance of OpenTelemetryMetricsSubscriber.
     pub fn new(push_controller: PushController) -> Self {
-        let inner: Instruments = Default::default();
-        let instruments = Arc::new(RwLock::new(inner));
         let meter = push_controller
             .provider()
             .meter(INSTRUMENTATION_LIBRARY_NAME, Some(CARGO_PKG_VERSION));
-        OpenTelemetryMetricsSubscriber { meter, instruments }
+        OpenTelemetryMetricsSubscriber {
+            meter,
+            instruments: Default::default(),
+        }
     }
 }
 


### PR DESCRIPTION
This commit makes some changes that should significantly reduce the
performance overhead of the OpenTelemetry metrics layer. In particular:

* The current code will allocate a `String` with the metric name _every_
  time a metric value is recorded, even if this value already exists.
  This is in order to use the `HashMap::entry` API. However, the
  performance cost of allocating a `String` and copying the metric
  name's bytes into that string is almost certainly worse than
  performing the hashmap lookup a second time, and that overhead occurs
  *every* time a metric is recorded.

  This commit changes the code for recording metrics to perform hashmap
  lookups by reference. This way, in the common case (where the metric
  already exists), we won't allocate. The allocation only occurs when a
  new metric is added to the map, which is infrequent.

* The current code uses a `RwLock` to protect the map of metrics.
  However, because the current code uses the `HashMap::entry` API,
  *every* metric update must acquire a write lock, since it may insert a
  new metric. This essentially reduces the `RwLock` to a `Mutex` ---
  since every time a value is recorded, we must acquire a write lock, we
  are forcing global synchronization on every update, the way a `Mutex`
  would. However, an OpenTelemetry metric can have its value updated
  through an `&self` reference (presumably metrics are represented as
  atomic values?). This means that the write lock is not necessary when
  a metric has already been recorded once, and multiple metric updates
  can occur without causing all threads to synchronize.

  This commit changes the code for updating metrics so that the read
  lock is acquired when attempting to look up a metric. If that metric
  exists, it is updated through the read lock, allowing multiple metrics
  to be updated without blocking every thread. In the less common case
  where a new metric is added, the write lock is acquired to update the
  hashmap.

* Currently, a *single* `RwLock` guards the *entire* `Instruments`
  structure. This is unfortunate. Any given metric event will only touch
  one of the hashmaps for different metric types, so two distinct types
  of metric *should* be able to be updated at the same time. The big
  lock prevents this, as a global write lock is acquired that prevents
  *any* type of metric from being updated.

  This commit changes this code to use more granular locks, with one
  around each different metric type's `HashMap`. This way, updating (for
  example) an `f64` counter does not prevent a `u64` value recorder from
  being updated at the same time, even when both metrics are inserted
  into the map for the first time.